### PR TITLE
Fix unrecognized arguments when loading debug app to Ledger

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -25,6 +25,10 @@ MY_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 include $(BOLOS_SDK)/Makefile.defines
 
+# Patch SDK
+COMMON_LOAD_PARAMS=--tlv --targetId $(TARGET_ID) --targetVersion="$(TARGET_VERSION)" --delete --fileName bin/app.hex --appName \"$(APPNAME)\" --appVersion $(APPVERSION) --dataSize $$((0x`cat debug/app.map |grep _envram_data | tr -s ' ' | cut -f2 -d' '|cut -f2 -d'x'` - 0x`cat debug/app.map |grep _nvram_data | tr -s ' ' | cut -f2 -d' '|cut -f2 -d'x'`)) `ICONHEX=\`python3 $(BOLOS_SDK)/icon3.py --hexbitmaponly $(ICONNAME)  2>/dev/null\` ; [ ! -z "$$ICONHEX" ] && echo "--icon $$ICONHEX"` $(PARAM_SCP)
+COMMON_DELETE_PARAMS=--targetId $(TARGET_ID) --appName \"$(APPNAME)\" $(PARAM_SCP)
+
 # Main app configuration
 APPNAME = "Crypto.com Chain"
 APPVERSION_M=2


### PR DESCRIPTION
I notice in this commit earlier the fix to the double quote issues during `loadApp` is removed:
https://github.com/LedgerHQ/app-cryptocom/commit/0d7e98567b66fdc04a7393587b5f70ddbd2d9e9a#diff-0c6c7defde945725f3d878fe20d0866dc29520f5f3816ff91ca56df2211e5451

However, after the line is removed, it will return the following error when trying to build it on Mac OS
`loadApp.py: error: unrecognized arguments: Chain`

This PR tries to revert this change by adding it back. Please let me know if I have overlooked anything related to this issue. Thank you.